### PR TITLE
Remove data.gov.uk from the list of users

### DIFF
--- a/app/views/pages/faq.en.html.erb
+++ b/app/views/pages/faq.en.html.erb
@@ -55,7 +55,6 @@
         <p>More and more governments and organisations from around the world are using Open Data Certificates every day. Current users include:</p>
 
         <ul>
-          <li>UK national government (data.gov.uk)</li>
           <li>Greater London Authority (data.london.gov.uk)</li>
           <li>Australia Queensland (data.qld.gov.au)</li>
           <li>Office of National Statistics</li>


### PR DESCRIPTION
We removed these certificates as our research showed users did not find them useful. 
Recently we received a support request from a user who was confused by this discrepancy, 
so we're proposing this change to avoid future confusion.

Changes proposed in this pull request: remove data.gov.uk from the list of users.